### PR TITLE
fix: conflict exception should extend `XGraphQL\SchemaGateway\Exception\RuntimeException` instead

### DIFF
--- a/src/Exception/ConflictException.php
+++ b/src/Exception/ConflictException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace XGraphQL\SchemaGateway\Exception;
 
-final class ConflictException extends \RuntimeException implements ExceptionInterface
+final class ConflictException extends RuntimeException implements ExceptionInterface
 {
     public function __construct(string $message, public readonly array $schemas)
     {


### PR DESCRIPTION
…on\RuntimeException` instead